### PR TITLE
Add testnet config option

### DIFF
--- a/mwixnet.yml
+++ b/mwixnet.yml
@@ -8,6 +8,10 @@ args:
       short: c
       long: config_file
       takes_value: true
+  - testnet:
+      help: Run grin against the Testnet (as opposed to mainnet)
+      long: testnet
+      takes_value: false
   - grin_node_url:
       help: Api address of running GRIN node on which to check inputs and post transactions
       short: n

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,12 +248,8 @@ pub fn grin_node_url(chain_type: &ChainTypes) -> SocketAddr {
 	}
 }
 
-pub fn wallet_owner_url(chain_type: &ChainTypes) -> SocketAddr {
-	if *chain_type == ChainTypes::Testnet {
-		"127.0.0.1:13420".parse().unwrap()
-	} else {
-		"127.0.0.1:3420".parse().unwrap()
-	}
+pub fn wallet_owner_url(_chain_type: &ChainTypes) -> SocketAddr {
+	"127.0.0.1:3420".parse().unwrap()
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::error::{self, Result};
 use crate::secp::SecretKey;
 
 use core::num::NonZeroU32;
+use grin_core::global::ChainTypes;
 use grin_util::{file, ToHex, ZeroingString};
 use rand::{thread_rng, Rng};
 use ring::{aead, pbkdf2};
@@ -12,7 +13,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 const GRIN_HOME: &str = ".grin";
-const CHAIN_NAME: &str = "main";
 const NODE_API_SECRET_FILE_NAME: &str = ".api_secret";
 const WALLET_OWNER_API_SECRET_FILE_NAME: &str = ".owner_api_secret";
 
@@ -218,24 +218,24 @@ pub fn load_config(config_path: &PathBuf, password: &ZeroingString) -> Result<Se
 	})
 }
 
-pub fn get_grin_path() -> PathBuf {
+pub fn get_grin_path(chain_type: &ChainTypes) -> PathBuf {
 	let mut grin_path = match dirs::home_dir() {
 		Some(p) => p,
 		None => PathBuf::new(),
 	};
 	grin_path.push(GRIN_HOME);
-	grin_path.push(CHAIN_NAME);
+	grin_path.push(chain_type.shortname());
 	grin_path
 }
 
-pub fn node_secret_path() -> PathBuf {
-	let mut path = get_grin_path();
+pub fn node_secret_path(chain_type: &ChainTypes) -> PathBuf {
+	let mut path = get_grin_path(chain_type);
 	path.push(NODE_API_SECRET_FILE_NAME);
 	path
 }
 
-pub fn wallet_owner_secret_path() -> PathBuf {
-	let mut path = get_grin_path();
+pub fn wallet_owner_secret_path(chain_type: &ChainTypes) -> PathBuf {
+	let mut path = get_grin_path(chain_type);
 	path.push(WALLET_OWNER_API_SECRET_FILE_NAME);
 	path
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,6 +240,22 @@ pub fn wallet_owner_secret_path(chain_type: &ChainTypes) -> PathBuf {
 	path
 }
 
+pub fn grin_node_url(chain_type: &ChainTypes) -> SocketAddr {
+	if *chain_type == ChainTypes::Testnet {
+		"127.0.0.1:13413".parse().unwrap()
+	} else {
+		"127.0.0.1:3413".parse().unwrap()
+	}
+}
+
+pub fn wallet_owner_url(chain_type: &ChainTypes) -> SocketAddr {
+	if *chain_type == ChainTypes::Testnet {
+		"127.0.0.1:13420".parse().unwrap()
+	} else {
+		"127.0.0.1:3420".parse().unwrap()
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,14 +70,20 @@ fn real_main() -> Result<(), Box<dyn std::error::Error>> {
 			key: secp::random_secret(),
 			interval_s: round_time.unwrap_or(DEFAULT_INTERVAL),
 			addr: bind_addr.unwrap_or("0.0.0.0:3000").parse()?,
-			grin_node_url: grin_node_url.unwrap_or("127.0.0.1:3413").parse()?,
+			grin_node_url: match grin_node_url {
+				Some(u) => u.parse()?,
+				None => config::grin_node_url(&chain_type),
+			},
 			grin_node_secret_path: match grin_node_secret_path {
 				Some(p) => Some(p.to_owned()),
 				None => config::node_secret_path(&chain_type)
 					.to_str()
 					.map(|p| p.to_owned()),
 			},
-			wallet_owner_url: wallet_owner_url.unwrap_or("127.0.0.1:3420").parse()?,
+			wallet_owner_url: match wallet_owner_url {
+				Some(u) => u.parse()?,
+				None => config::wallet_owner_url(&chain_type),
+			},
 			wallet_owner_secret_path: match wallet_owner_secret_path {
 				Some(p) => Some(p.to_owned()),
 				None => config::wallet_owner_secret_path(&chain_type)


### PR DESCRIPTION
Resolves https://github.com/mimblewimble/mwixnet/issues/6

Supply the `--testnet` command line option to use or create a testnet mwixnet config, which runs against GRIN's test network.

Unless overridden, the config will be at `~/.grin/test/mwixnet-config.toml` and will use ports 13413(node) and 3420(wallet), and api secret file paths `~/.grin/test/.api_secret`(node) and `~/.grin/test/.owner_api_secret`(wallet).