### PR TITLE
Tor support & x25519 encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "nom 7.1.0",
  "pin-project",
  "rand 0.7.3",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rust-embed",
  "scrypt",
  "sha2 0.9.8",
@@ -65,7 +65,7 @@ dependencies = [
  "cookie-factory",
  "hkdf",
  "nom 7.1.0",
- "rand 0.8.4",
+ "rand 0.8.5",
  "secrecy 0.8.0",
  "sha2 0.9.8",
 ]
@@ -2475,7 +2475,9 @@ dependencies = [
  "bytes 0.5.6",
  "chacha20",
  "clap",
+ "curve25519-dalek 2.1.3",
  "dirs",
+ "ed25519-dalek",
  "futures 0.3.17",
  "grin_api 5.2.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
  "grin_chain 5.2.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
@@ -2488,6 +2490,7 @@ dependencies = [
  "grin_wallet_api",
  "grin_wallet_impls",
  "grin_wallet_libwallet",
+ "grin_wallet_util",
  "hmac 0.12.0",
  "hyper 0.14.14",
  "itertools",
@@ -2496,7 +2499,7 @@ dependencies = [
  "jsonrpc-http-server",
  "lazy_static",
  "pbkdf2 0.8.0",
- "rand 0.8.4",
+ "rand 0.7.3",
  "ring",
  "rpassword",
  "serde",
@@ -2506,6 +2509,7 @@ dependencies = [
  "thiserror",
  "tokio 1.12.0",
  "toml",
+ "x25519-dalek 0.6.0",
 ]
 
 [[package]]
@@ -3033,14 +3037,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -3122,15 +3125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3854,7 +3848,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.4",
+ "rand 0.8.5",
  "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ byteorder = "1"
 bytes = "0.5.6"
 chacha20 = "0.8.1"
 clap = { version = "2.33", features = ["yaml"] }
+curve25519-dalek = "2.1"
 dirs = "2.0"
+ed25519-dalek = "1.0.1"
 futures = "0.3"
 hmac = { version = "0.12.0", features = ["std"]}
 hyper = { version = "0.14", features = ["full"] }
@@ -21,7 +23,7 @@ jsonrpc-derive = "18.0"
 jsonrpc-http-server = "18.0"
 lazy_static = "1"
 pbkdf2 = "0.8.0"
-rand = "0.8.4"
+rand = "0.7.3"
 ring = "0.16"
 rpassword = "4.0"
 serde = { version = "1", features= ["derive"]}
@@ -31,6 +33,7 @@ sha2 = "0.10.0"
 thiserror = "1.0.31"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
+x25519-dalek = "0.6.0"
 grin_secp256k1zkp = { version = "0.7.11", features = ["bullet-proof-sizing"]}
 grin_util = "5"
 grin_api = { git = "https://github.com/mimblewimble/grin", version = "5.2.0-alpha.1" }
@@ -42,3 +45,4 @@ grin_store = { git = "https://github.com/mimblewimble/grin", version = "5.2.0-al
 grin_wallet_api = { git = "https://github.com/mimblewimble/grin-wallet", branch = "master" }
 grin_wallet_impls = { git = "https://github.com/mimblewimble/grin-wallet", branch = "master" }
 grin_wallet_libwallet = { git = "https://github.com/mimblewimble/grin-wallet", branch = "master" }
+grin_wallet_util = { git = "https://github.com/mimblewimble/grin-wallet", branch = "master" }

--- a/mwixnet.yml
+++ b/mwixnet.yml
@@ -35,7 +35,7 @@ args:
       long: wallet_pass
       takes_value: true
   - bind_addr:
-      help: Address to bind the rpc server to (e.g. 0.0.0.0:3000)
+      help: Address to bind the rpc server to (e.g. 127.0.0.1:3000)
       long: bind_addr
       takes_value: true
 subcommands:

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -100,7 +100,6 @@ pub fn listen(
 	};
 
 	let http_server = rpc_server.start_http();
-	println!("Server listening on {}", server_config.addr);
 
 	let close_handle = http_server.close_handle();
 	let round_handle = spawn(move || {

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -218,7 +218,7 @@ pub fn sign(sk: &SecretKey, msg: &Message) -> Result<Signature, secp256k1zkp::Er
 
 #[cfg(test)]
 pub mod test_util {
-	use crate::secp::{self, Commitment, PublicKey, RangeProof, Secp256k1};
+	use crate::secp::{self, Commitment, RangeProof, Secp256k1};
 	use grin_core::core::hash::Hash;
 	use grin_util::ToHex;
 	use rand::RngCore;
@@ -241,11 +241,6 @@ pub mod test_util {
 			None,
 			None,
 		)
-	}
-
-	pub fn rand_pubkey() -> PublicKey {
-		let secp = Secp256k1::new();
-		PublicKey::from_secret_key(&secp, &secp::random_secret()).unwrap()
 	}
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -270,9 +270,7 @@ mod tests {
 	use crate::node::mock::MockGrinNode;
 	use crate::onion::test_util::{self, Hop};
 	use crate::onion::Onion;
-	use crate::secp::{
-		self, ComSignature, Commitment, PublicKey, RangeProof, Secp256k1, SecretKey,
-	};
+	use crate::secp::{self, ComSignature, Commitment, RangeProof, Secp256k1, SecretKey};
 	use crate::server::{Server, ServerImpl, SwapError};
 	use crate::store::{SwapData, SwapStatus, SwapStore};
 	use crate::types::Payload;
@@ -283,6 +281,8 @@ mod tests {
 	use grin_core::global::{self, ChainTypes};
 	use std::net::TcpListener;
 	use std::sync::Arc;
+	use x25519_dalek::PublicKey as xPublicKey;
+	use x25519_dalek::StaticSecret;
 
 	macro_rules! assert_error_type {
 		($result:expr, $error_type:pat) => {
@@ -351,9 +351,8 @@ mod tests {
 		fee: u64,
 		proof: Option<RangeProof>,
 	) -> Hop {
-		let secp = Secp256k1::new();
 		Hop {
-			pubkey: PublicKey::from_secret_key(&secp, &server_key).unwrap(),
+			pubkey: xPublicKey::from(&StaticSecret::from(server_key.0.clone())),
 			payload: Payload {
 				excess: hop_excess.clone(),
 				fee: FeeFields::from(fee as u32),


### PR DESCRIPTION
While adding in tor support, I realized we would be better off using x25519 encryption. This allows us to use a single public key for encryption and onion address, the same way we do for slatepacks.