### PR TITLE
Add option to output public address

### DIFF
--- a/src/bin/mwixnet.rs
+++ b/src/bin/mwixnet.rs
@@ -124,7 +124,17 @@ fn real_main() -> Result<(), Box<dyn std::error::Error>> {
 				config_path.to_string_lossy()
 			);
 		}
-		println!("{}", server_config.onion_address());
+		let sub_args = args.subcommand_matches("address").unwrap();
+		if sub_args.is_present("output_file") 
+		{
+			//output onion address to file
+			let output_file = sub_args.value_of("output_file").unwrap();
+			let onion_address = server_config.onion_address();
+			std::fs::write(output_file, format!("{}", onion_address))?;
+			println!("Onion address written to file: {}", output_file);
+		} else {
+			println!("{}", server_config.onion_address());
+		}
 		return Ok(())
 	}
 

--- a/src/bin/mwixnet.rs
+++ b/src/bin/mwixnet.rs
@@ -116,6 +116,18 @@ fn real_main() -> Result<(), Box<dyn std::error::Error>> {
 	let password = prompt_password();
 	let mut server_config = config::load_config(&config_path, &password)?;
 
+	// Write a new config file if init-config command is supplied
+	if let ("address", Some(_)) = args.subcommand() {
+		if !config_path.exists() {
+			panic!(
+				"No public address configured (Config file not found). {}",
+				config_path.to_string_lossy()
+			);
+		}
+		println!("{}", server_config.onion_address());
+		return Ok(())
+	}
+
 	// Override grin_node_url, if supplied
 	if let Some(grin_node_url) = grin_node_url {
 		server_config.grin_node_url = grin_node_url.parse()?;

--- a/src/bin/mwixnet.yml
+++ b/src/bin/mwixnet.yml
@@ -49,3 +49,5 @@ args:
 subcommands:
   - init-config:
       about: Writes a new configuration file
+  - address:
+      about: Displays the public key of the server

--- a/src/bin/mwixnet.yml
+++ b/src/bin/mwixnet.yml
@@ -50,4 +50,11 @@ subcommands:
   - init-config:
       about: Writes a new configuration file
   - address:
-      about: Displays the public key of the server
+      about: Outputs the public key of the server
+      args:
+        - output_file:
+            help: Path to output the public key to
+            long: output_file
+            short: o
+            takes_value: true   
+            required: false


### PR DESCRIPTION
To aid in container configuration, this adds an `address` subcommand that outputs the server's public address to stdout or a specified file. Previously, there was no way to get this information other than parsing output logs.